### PR TITLE
Dependencies update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ v2 is a complete re-write, replacing PostGIS with the S2 library, and enabling a
 
 - [s2geometry](http://s2geometry.io) v0.10.0
 - Cython
-- [SQLAlchemy](https://www.sqlalchemy.org/)
-- PostgresSQL. A database dialect for SQLAlchemy may also be needed, e.g., psycopg.
-- astropy
+- [SQLAlchemy]https://www.sqlalchemy.org/)
+- PostgresSQL.
+- [astropy](https://astropy.readthedocs.io/en/latest/)
 - [astroquery](https://astroquery.readthedocs.io/en/latest/)
 - [sbpy](https://github.com/NASA-Planetary-Science/sbpy)
 

--- a/README.md
+++ b/README.md
@@ -11,18 +11,19 @@ v2 is a complete re-write, replacing PostGIS with the S2 library, and enabling a
 
 ## Requirements
 
-- Python 3.8+
 - [s2geometry](http://s2geometry.io) v0.10.0
 - Cython
-- [SQLAlchemy](https://www.sqlalchemy.org/) 1.3
+- [SQLAlchemy](https://www.sqlalchemy.org/)
 - PostgresSQL. A database dialect for SQLAlchemy may also be needed, e.g., psycopg.
-- astropy >=4.3
-- [astroquery](https://astroquery.readthedocs.io/en/latest/) 0.4.4dev7007+
-- [sbpy](https://github.com/NASA-Planetary-Science/sbpy) >0.3.0
+- astropy
+- [astroquery](https://astroquery.readthedocs.io/en/latest/)
+- [sbpy](https://github.com/NASA-Planetary-Science/sbpy)
 
 Optional packages:
 
 - pytest, coverage, testing.postgresql and submodules for running the tests
+
+See pyproject.toml for versions.
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ authors = [{ name = "Michael S. P. Kelley", email = "msk@astro.umd.edu" }]
 license = { text = "BSD 3-Clause License" }
 requires-python = ">=3.10"
 dependencies = [
-    "numpy>=2",
-    "astropy>=6",
+    "numpy>=2.0",
+    "astropy>=7.1.2",
     "astroquery>=0.4.11",
     "sbpy>=0.6.0",
     "sqlalchemy>=2.0",
@@ -40,13 +40,14 @@ dynamic = ["version"]
 Repository = "https://github.com/Small-Bodies-Node/sbsearch"
 
 [project.optional-dependencies]
-recommended = ["psycopg[binary,pool]", "matplotlib", "spherical_geometry"]
+recommended = ["psycopg[binary,pool]>=3.0", "matplotlib", "spherical_geometry"]
 
 test = [
+    "coverage",
+    "psycopg[binary,pool]>=3.0",
     "pytest>=8",
     "pytest-astropy",
     "pytest-xdist",
-    "coverage",
     "testing.postgresql",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "wheel",
     "extension-helpers",
     "numpy",
-    "cython>=0.30",
+    "cython>=3",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -24,14 +24,14 @@ keywords = [
 readme = "README.md"
 authors = [{ name = "Michael S. P. Kelley", email = "msk@astro.umd.edu" }]
 license = { text = "BSD 3-Clause License" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
-    "numpy>=1.17.0,<2",
-    "astropy>=4.3",
-    "astroquery>=0.4.5",
-    "sbpy>0.3.0",
+    "numpy>=2",
+    "astropy>=6",
+    "astroquery>=0.4.11",
+    "sbpy>=0.6.0",
     "sqlalchemy>=2.0",
-    "cython>=0.30",
+    "cython>=3",
     "extension-helpers",
 ]
 dynamic = ["version"]
@@ -40,10 +40,10 @@ dynamic = ["version"]
 Repository = "https://github.com/Small-Bodies-Node/sbsearch"
 
 [project.optional-dependencies]
-recommended = ["psycopg2-binary", "matplotlib", "spherical_geometry"]
+recommended = ["psycopg[binary,pool]", "matplotlib", "spherical_geometry"]
 
 test = [
-    "pytest>=4.6",
+    "pytest>=8",
     "pytest-astropy",
     "pytest-xdist",
     "coverage",
@@ -62,7 +62,7 @@ include-package-data = false
 write_to = "sbsearch/version.py"
 
 [tool.pytest.ini_options]
-minversion = 4.6
+minversion = 8.0
 addopts = "--doctest-rst --cov=sbsearch --cov-report=html"
 doctest_plus = "enabled"
 remote_data_strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "sbpy>=0.6.0",
     "sqlalchemy>=2.0",
     "cython>=3",
+    "psycopg[binary,pool]>=3.0",
     "extension-helpers",
 ]
 dynamic = ["version"]
@@ -40,11 +41,10 @@ dynamic = ["version"]
 Repository = "https://github.com/Small-Bodies-Node/sbsearch"
 
 [project.optional-dependencies]
-recommended = ["psycopg[binary,pool]>=3.0", "matplotlib", "spherical_geometry"]
+recommended = ["matplotlib", "spherical_geometry"]
 
 test = [
     "coverage",
-    "psycopg[binary,pool]>=3.0",
     "pytest>=8",
     "pytest-astropy",
     "pytest-xdist",

--- a/sbsearch/test/__init__.py
+++ b/sbsearch/test/__init__.py
@@ -7,19 +7,26 @@ from ..sbsdb import SBSDatabase
 Postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=True)
 
 
-@pytest.fixture(name='sbs')
+def get_url(postgresql):
+    # use psycopg dialect, which will not be the default for sqlalchemy until
+    # 2.1
+    return postgresql.url().replace("postgresql://", "postgresql+psycopg://")
+
+
+@pytest.fixture(name="sbs")
 def fixture_sbs() -> SBSearch:
     with Postgresql() as postgresql:
-        engine: sa.engine.Engine = sa.create_engine(postgresql.url())
+        engine: sa.engine.Engine = sa.create_engine(get_url(postgresql))
         sessionmaker: sa.orm.sessionmaker = sa.orm.sessionmaker(bind=engine)
-        with SBSearch(sessionmaker(), min_edge_length=0.01,
-                      max_edge_length=0.17) as sbs:
+        with SBSearch(
+            sessionmaker(), min_edge_length=0.01, max_edge_length=0.17
+        ) as sbs:
             yield sbs
 
 
-@pytest.fixture(name='db')
+@pytest.fixture(name="db")
 def fixture_db():
     with Postgresql() as postgresql:
-        db = SBSDatabase.test_db(postgresql.url())
+        db = SBSDatabase.test_db(get_url(postgresql))
         yield db
         db.close()

--- a/sbsearch/test/test_sbsdb.py
+++ b/sbsearch/test/test_sbsdb.py
@@ -6,14 +6,14 @@ import sqlalchemy as sa
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.sql import text
 
-from . import fixture_db, Postgresql
+from . import fixture_db, get_url, Postgresql
 from ..sbsdb import SBSDatabase
 
 
 class TestSBSDatabase:
     def test_init_session(self):
         with Postgresql() as postgresql:
-            engine = sa.create_engine(postgresql.url())
+            engine = sa.create_engine(get_url(postgresql))
             sessionmaker = sa.orm.sessionmaker(bind=engine)
             session = sessionmaker()
             db = SBSDatabase(session)

--- a/sbsearch/test/test_sbsearch.py
+++ b/sbsearch/test/test_sbsearch.py
@@ -15,7 +15,7 @@ from ..ephemeris import get_ephemeris_generator
 from ..target import MovingTarget, FixedTarget
 from ..exceptions import UnknownSource, DesignationError
 from ..config import Config
-from . import fixture_sbs, Postgresql  # noqa: F401
+from . import fixture_sbs, Postgresql, get_url  # noqa: F401
 
 
 @pytest.fixture(name="observations")
@@ -39,7 +39,7 @@ class TestSBSearch:
     def test_with_config(self) -> None:
         with Postgresql() as postgresql:
             config: Config = Config(
-                database=postgresql.url(),
+                database=get_url(postgresql),
                 min_edge_length=0.01,
                 max_edge_length=0.17,
                 uncertainty_ellipse=True,

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
-    py{38,39,310,311,dev}-test
+    py{310,311,312,313,314,dev}-test
     codestyle
 requires =
-    setuptools >= 30.3.0
-    pip >= 19.3.1
-    tox-pypi-filter >= 0.12
+    setuptools >= 74
+    pip >= 24
+    tox-pypi-filter >= 0.15
 isolated_build = true
 pass_env =
     LDFLAGS
@@ -20,7 +20,7 @@ description =
     run tests
 
 deps =
-    psycopg2-binary
+    psycopg[binary,pool]
 
 
 # The following indicates which extras_require from setup.cfg will be installed


### PR DESCRIPTION
Bump numpy to > 2, and python to 3.10 or later.  With psycopg v3, numpy v2 type conversions will be handled seamlessly, so make this a direct dependency.  This will also require astropy 7.1.2 or later.